### PR TITLE
Fix out-of-memory with doCommand() in batch mode

### DIFF
--- a/ij/Executer.java
+++ b/ij/Executer.java
@@ -106,6 +106,8 @@ public class Executer implements Runnable {
 				} else
 					IJ.log(s);
 			}
+		} finally {
+			WindowManager.setTempCurrentImage(null);
 		}
 	}
 	


### PR DESCRIPTION
WindowManager's tempImageMap could still hold temporary images after
the batch mode was canceled. Avoid that by releasing temporary images
at the end of the thread.

This fixes the issue reported by Hans Wurscht.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
