### PR TITLE
Update MontageMaker.java

### DIFF
--- a/ij/plugin/MontageMaker.java
+++ b/ij/plugin/MontageMaker.java
@@ -167,7 +167,6 @@ public class MontageMaker implements PlugIn {
 		montage.setColor(bgColor);
 		montage.fill();
 		montage.setColor(fgColor);
-		Dimension screen = IJ.getScreenSize();
 		montage.setFont(new Font("SansSerif", Font.PLAIN, fontSize));
 		montage.setAntialiasedText(true);
 		ImageStack stack = imp.getStack();


### PR DESCRIPTION
The field 'screen' is not used and invocation of IJ.getScreenSize() may result in java.lang.ArrayIndexOutOfBoundsException. Thus it's removed.
