### PR TITLE
Added virtual machine shutdown hook to save preferences.

### DIFF
--- a/ij/ImageJ.java
+++ b/ij/ImageJ.java
@@ -703,7 +703,7 @@ public class ImageJ extends Frame implements ActionListener,
 			public void run() {
 				ImageJ instance = IJ.getInstance();
 				if(instance != null) {
-					if(instance.applet == null) {
+					if(instance.applet != null) {
 						Prefs.savePreferences();
 						instance.saveWindowLocations();
 					}


### PR DESCRIPTION
When ImageJ is run from a terminal and closed with CTRL-C, preferences are not saved.  I've added a shutdown hook for the JVM to automatically save preferences when ImageJ is closed in this way.
