### PR TITLE
Added virtual machine shutdown hook to save preferences.

### DIFF
--- a/ij/ImageJ.java
+++ b/ij/ImageJ.java
@@ -703,7 +703,7 @@ public class ImageJ extends Frame implements ActionListener,
 			public void run() {
 				ImageJ instance = IJ.getInstance();
 				if(instance != null) {
-					if(instance.applet != null) {
+					if(instance.applet == null) {
 						Prefs.savePreferences();
 						instance.saveWindowLocations();
 					}


### PR DESCRIPTION
When ImageJ is terminated using Ctrl-C or the JVM is otherwise shutdown, ImageJ does not save its preferences.  I've added a shutdown hook to handle such cases.
