### PR TITLE
Constructors changed so that hideWindow is evaluated.

### DIFF
--- a/ij/plugin/frame/RoiManager.java
+++ b/ij/plugin/frame/RoiManager.java
@@ -69,21 +69,23 @@ public class RoiManager extends PlugInFrame implements ActionListener, ItemListe
 	private boolean allowRecording;
 		
 	public RoiManager() {
-		super("ROI Manager");
-		if (instance!=null) {
-			WindowManager.toFront(instance);
-			return;
-		}
-		instance = this;
-		list = new JList();
-		showWindow();
+		this(false);
 	}
 	
 	public RoiManager(boolean hideWindow) {
 		super("ROI Manager");
 		list = new JList();
-		listModel = new DefaultListModel();
-		list.setModel(listModel);
+		if (!hideWindow) {
+			if (instance!=null) {
+				WindowManager.toFront(instance);
+				return;
+			}
+			instance = this;
+			showWindow();
+		} else {
+			listModel = new DefaultListModel();
+			list.setModel(listModel);
+		}
 	}
 
 	void showWindow() {


### PR DESCRIPTION
Hello Wayne,

today I used the constructor public RoiManager(boolean hideWindow) in a plugin for test reasons with hideWindow=false and woundered why the RoiManager window doesn't show up. I made some changes so that the hideWindow is evaluated.

Best Christian Moll