### PR TITLE
Fix inconsistency in Animator

### DIFF
--- a/ij/plugin/Animator.java
+++ b/ij/plugin/Animator.java
@@ -100,8 +100,10 @@ public class Animator implements PlugIn {
 		Calibration cal = imp.getCalibration();
 		if (cal.fps!=0.0)
 			animationRate = cal.fps;
-		if (animationRate<0.1)
+		if (animationRate<0.1) {
 			animationRate = 1.0;
+			cal.fps = animationRate;
+		}
 		int frames = imp.getNFrames();
 		int slices = imp.getNSlices();
 		


### PR DESCRIPTION
The computed `animationRate` (i.e. the one extracted from the meta data) is overwritten to 1.0 when it is less than 0.1. The overwritten value is never picked up by the `GenericDialog` since it is not written back to the `calibration.fps` field, which is fixed with this commit.