### PR TITLE
corrected RGBtoYUV conversion for proper ColorThresholder macro usage

### DIFF
--- a/ij/plugin/frame/ColorThresholder.java
+++ b/ij/plugin/frame/ColorThresholder.java
@@ -1363,7 +1363,7 @@ public class ColorThresholder extends PlugInFrame implements PlugIn, Measurement
 	public static void RGBtoYUV() {
 		ImagePlus imp = IJ.getImage();
 		if (imp.getBitDepth()==24) {
-			RGBtoLab(imp.getProcessor());
+			RGBtoYUV(imp.getProcessor());
 			imp.updateAndDraw();
 		}
 	}


### PR DESCRIPTION
Dear Wayne,

the following change should enable the proper functionality of the RGBtoYUV conversion using the ColorThresholder in a macro.
Kind regards,
Jan