### PR TITLE
TIFF Decoder: fix typo in ARTIST tag parsing

### DIFF
--- a/ij/io/TiffDecoder.java
+++ b/ij/io/TiffDecoder.java
@@ -29,7 +29,7 @@ public class TiffDecoder {
 	public static final int RESOLUTION_UNIT = 296;
 	public static final int SOFTWARE = 305;
 	public static final int DATE_TIME = 306;
-	public static final int ARTEST = 315;
+	public static final int ARTIST = 315;
 	public static final int HOST_COMPUTER = 316;
 	public static final int PREDICTOR = 317;
 	public static final int COLOR_MAP = 320;
@@ -333,7 +333,7 @@ public class TiffDecoder {
 			case RESOLUTION_UNIT: name="ResolutionUnit"; break;
 			case SOFTWARE: name="Software"; break;
 			case DATE_TIME: name="DateTime"; break;
-			case ARTEST: name="Artest"; break;
+			case ARTIST: name="Artist"; break;
 			case HOST_COMPUTER: name="HostComputer"; break;
 			case PLANAR_CONFIGURATION: name="PlanarConfiguration"; break;
 			case COMPRESSION: name="Compression"; break; 
@@ -513,7 +513,7 @@ public class TiffDecoder {
 							"compressed in this fashion ("+value+")");
 					}
 					break;
-				case SOFTWARE: case DATE_TIME: case HOST_COMPUTER: case ARTEST:
+				case SOFTWARE: case DATE_TIME: case HOST_COMPUTER: case ARTIST:
 					if (ifdCount==1) {
 						byte[] bytes = getString(count, lvalue);
 						String s = bytes!=null?new String(bytes):null;


### PR DESCRIPTION
Instead of referring to the ARTIST tag, the decoder expects an ARTEST tag (E instead of I). This looks like a typo, given that the TIFF spec defines the ARTIST tag with the same numeric code 315, e.g.:

https://www.awaresystems.be/imaging/tiff/tifftags/artist.html

This typo is fixed now and the ARTIST tag is parsed properly.