### PR TITLE
Add group names

### DIFF
--- a/ij/Prefs.java
+++ b/ij/Prefs.java
@@ -60,6 +60,8 @@ public class Prefs {
 		CANCEL_BUTTON_ON_RIGHT=1<<10, IGNORE_RESCALE_SLOPE=1<<11,
 		NON_BLOCKING_DIALOGS=1<<12;
 	public static final String OPTIONS2 = "prefs.options2";
+	
+	private static Map<Integer, String> roiGroupNames = new TreeMap<Integer, String>();
     
 	/** file.separator system property */
 	public static String separator = System.getProperty("file.separator");
@@ -395,6 +397,21 @@ public class Prefs {
 	/** Returns the file.separator system property. */
 	public static String getFileSeparator() {
 		return separator;
+	}
+	
+	/** Returns the saved group names mapping */
+	public static Map<Integer, String> getGroupNameMap(){
+		return new TreeMap<Integer, String>(roiGroupNames);
+	}
+	
+	/** Set the groupName mapping */
+	public static void setGroupNameMap(Map<Integer, String> groupNames) {
+		roiGroupNames = new TreeMap<Integer, String>(groupNames);
+	}
+	
+	/** Set the groupName mapping from a already ordered Map */
+	public static void setGroupNameMap(TreeMap<Integer, String> groupNames) {
+		roiGroupNames = groupNames;
 	}
 
 	/** Opens the ImageJ preferences file ("IJ_Prefs.txt") file. */

--- a/ij/gui/Roi.java
+++ b/ij/gui/Roi.java
@@ -75,6 +75,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	private static LUT glasbeyLut;
 	private static int defaultGroup; // zero is no specific group
 	private static Color groupColor;
+	static Map<Integer, String> groupNames = Prefs.getGroupNameMap();
 	private static double defaultStrokeWidth;
 	
 	protected int type;
@@ -1733,8 +1734,41 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	public int getGroup() {
 		return this.group;
 	}
-
-	/** Sets the group of this Roi, and updates stroke color accordingly. */
+	
+	/** Return the group name of this ROI, in the current state of the group:name mapping */
+	public String getGroupName() {
+		return getNameOfGroup( this.getGroup() );
+		}
+	
+	/** Return the name associated to a given group **/
+	public static String getNameOfGroup(int group) {
+		if ( groupNames.containsKey(group) ) 
+			return groupNames.get(group);
+		else
+			return new String("group") + String.valueOf(group); // or should it return None ?
+	}
+	
+	/** Add or update a group name **/
+	public static void setNameOfGroup(int group, String name) {
+		groupNames.put(group, name);
+	}
+	
+	/** Return the mapping group:name **/
+	public static Map<Integer, String> getGroupNameMap(){
+		return new TreeMap<Integer, String>(Roi.groupNames); // return a copy (safer)
+	}
+	
+	/** Replace existing group name mapping, the mapping is automatically sorted by keys **/
+	public static void setGroupNameMap(Map<Integer, String> groupNames) {
+		Roi.groupNames = new TreeMap<Integer, String>(groupNames);
+	}
+	
+	/** Replace existing group name mapping, with a already sorted Map (TreeMap) **/
+	public static void setGroupNameMap(TreeMap<Integer, String> groupNames) {
+		Roi.groupNames = groupNames;
+	}
+	
+	/** Sets the group of this Roi, and updates stroke color and name accordingly. */
 	public void setGroup(int group) {
 		if (group<0 || group>255)
 			throw new IllegalArgumentException("Invalid group: "+group);

--- a/ij/gui/RoiGroupTable.java
+++ b/ij/gui/RoiGroupTable.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 1995, 2008, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Oracle or the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */ 
+
+package ij.gui;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.*;
+
+public class RoiGroupTable extends Panel {
+	
+    /**
+	 * Implement a table with 2 columns: Roi group number and associated name.
+     * This table can be edited to set new names for roi groups
+	 */
+	private static final long serialVersionUID = 1L;
+	private RoiGroupTableModel tableModel;
+    
+    public RoiGroupTable() {
+        super(new GridLayout(0,1)); // 1 column, as many rows as necessary
+    	         
+        this.tableModel = new RoiGroupTableModel(); 
+        final JTable table = new JTable(tableModel);
+        table.setPreferredScrollableViewportSize(new Dimension(500, 70));
+        table.setFillsViewportHeight(true);
+        
+        // Handle row selection
+        //table.getSelectionModel().addListSelectionListener(new RowListener());
+        //table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        table.setRowSelectionAllowed(true);
+
+
+        //Create the scroll pane and add the table to it.
+        JScrollPane scrollPane = new JScrollPane(table);
+        //ScrollPane scrollPane = new ScrollPane();
+        //scrollPane.add(table);
+        
+        //Add the scroll pane to this panel.
+        add(scrollPane);
+        
+        
+        // LABEL PANEL
+        JPanel labelPanel = new JPanel(new GridLayout(0,2));
+        //Panel labelPanel = new Panel(new GridLayout(0,2));
+        //Panel labelPanel = new Panel(); // looks bad when resizing
+        
+        // Add label 
+        JLabel label1 = new JLabel("Group number");
+        JLabel label2 = new JLabel("Name");
+        labelPanel.add(label1);
+        labelPanel.add(label2);
+        add(labelPanel);
+        
+        
+        // BUTTON PANNEL
+        JPanel buttonPanel = new JPanel(new GridLayout(0,3));
+        //Panel buttonPanel = new Panel();
+
+        
+        // Add spinner for group number
+        SpinnerNumberModel rangeInt = new SpinnerNumberModel(0,0,255,1);
+        final JSpinner spinner = new JSpinner(rangeInt); // final needed here for some reason
+        buttonPanel.add(spinner);
+        
+        // Add text field for group name
+        final JTextField nameField = new JTextField("new group");
+        buttonPanel.add(nameField);
+        
+        
+        // Class defining action of button : Adding a row to table
+        class AddButton extends JButton implements ActionListener{
+        	
+        	public AddButton() {
+        		super("Add/Update row");
+        		this.addActionListener(this);
+        	}
+        				 
+    		public void actionPerformed(ActionEvent event){
+    			
+    			// Get group number and name
+    			SpinnerNumberModel spinModel = (SpinnerNumberModel) spinner.getModel();
+    			int newNumber = spinModel.getNumber().intValue(); 
+    			String newGroup = nameField.getText();
+    			
+    			// Check if group number already in table
+    			Vector numbers = tableModel.getColumn(0);
+    			int row = numbers.indexOf(newNumber);
+    			
+    			if ( row==-1 ) {
+	    			// new Number not in table -> Add a new row
+	    			tableModel.addRow(newNumber, newGroup);
+    			}
+    			else {
+    				// Update existing row
+    				tableModel.setValueAt(newGroup, row, 1);
+    			}
+    		}
+        }
+        
+        // Button "Add Row"
+        //JButton buttonAdd = new AddButton();
+        buttonPanel.add(new AddButton());
+        
+        
+        // Class defining action of button : Adding a row to table
+        class DeleteButton extends JButton implements ActionListener{
+        	
+        	public DeleteButton() {
+        		super("Delete selected row");
+        		this.addActionListener(this);
+        	}
+        				 
+    		public void actionPerformed(ActionEvent event){
+    			
+    			int row = table.getSelectedRow(); // _Had to set Table to final
+    			
+    			if ( row!=-1 ) tableModel.deleteRow(row);
+    		}
+        }
+        
+        buttonPanel.add(new DeleteButton());
+                
+        
+        // Add button panel to main panel
+        add(buttonPanel);
+        
+    }
+
+    /**
+     * Create the GUI and show it.  For thread safety,
+     * this method should be invoked from the
+     * event-dispatching thread.
+     */
+    public void showTable() {
+    	GenericDialog gd = new GenericDialog("Roi-group table");
+    	gd.addPanel(this); // Add current table instance to panel
+    	gd.showDialog();
+    	
+    	if ( gd.wasOKed() ) {
+	    	Vector<Integer> columnGroups = this.tableModel.getColumn(0);
+	    	Vector<String> columnNames   = this.tableModel.getColumn(1); 
+	    	
+	    	int nRows = this.tableModel.getRowCount();
+	    	Map<Integer, String> newMapping = new HashMap<Integer, String>(nRows);
+	    	
+	    	for (int i=0; i<nRows; i++) {
+	    		newMapping.put( columnGroups.get(i) , columnNames.get(i) );
+	    	
+	    	Roi.setGroupNameMap(newMapping);
+	    	}
+    	}
+    }
+
+}

--- a/ij/gui/RoiGroupTable.java
+++ b/ij/gui/RoiGroupTable.java
@@ -180,5 +180,7 @@ public class RoiGroupTable extends Panel {
 	    	}
     	}
     }
+    
+    public RoiGroupTableModel getTableModel(){ return this.tableModel; }
 
 }

--- a/ij/gui/RoiGroupTableModel.java
+++ b/ij/gui/RoiGroupTableModel.java
@@ -1,0 +1,81 @@
+package ij.gui;
+
+import java.util.*;
+
+import javax.swing.table.AbstractTableModel;
+import javax.swing.*;
+import java.awt.Panel;
+import ij.gui.GenericDialog;
+
+
+public class RoiGroupTableModel extends AbstractTableModel{
+	
+	static final String[] headers = {"Group number", "Name"};
+	private Map<Integer, String> groupNames;
+	private Vector<Vector> columns = new Vector(2); // 2 columns
+	
+	public RoiGroupTableModel() {
+		super();
+		this.groupNames = Roi.groupNames;
+		//this.groupNames = new TreeMap<Integer, String>(groupNames); // sort the map by keys to makes sure keySet and values are ordered the same
+		
+		// Populate the column vectors
+		int size = this.groupNames.size();
+		Vector<Integer> columnGroups = new Vector<Integer>(size);
+		Vector<String>  columnNames  = new Vector<String>(size);
+		
+		for (Map.Entry<Integer, String> entry : this.groupNames.entrySet()) {
+			columnGroups.add(entry.getKey().intValue());
+			columnNames.add(entry.getValue());
+		}
+		
+		// Populate the 2D-data vector containing the 2 column vector
+		this.columns.add(columnGroups);
+		this.columns.add(columnNames);	
+		}
+	
+	public Class<?> getColumnClass(int index){
+		if (index==0) {return int.class;}
+		else {return String.class;}
+	}
+	
+	public int getRowCount() {return this.columns.get(0).size();}
+
+	public int getColumnCount() {return 2;}
+
+	public Object getValueAt(int row, int column) {
+			return this.columns.get(column).get(row);
+	}
+			
+	public Vector getColumn(int column) {
+			return this.columns.get(column);
+	}
+	
+	public String getColumnName(int column) {return RoiGroupTableModel.headers[column];}
+    	
+	public boolean isCellEditable(int row, int col) { return true; } // does not work for integer column
+
+    public void setValueAt(Object value, int row, int column) {
+    	this.columns.get(column).set(row, value);
+		fireTableCellUpdated(row, column);
+    }
+    
+    public void addRow(int group, String name) {
+    	this.columns.get(0).add(group);
+    	this.columns.get(1).add(name);
+    	int n = this.getRowCount();
+    	fireTableRowsInserted(n-1, n-1);
+    }
+    
+    public void deleteRow(int row) {
+    	this.columns.get(0).removeElementAt(row);
+    	this.columns.get(1).removeElementAt(row);
+    	fireTableRowsDeleted(row, row);
+    }
+    
+    public void deleteRows(int first, int last) {
+    	
+    	//this.columns.get(0).removeRange(first, last); //removeRange is protected ><
+    }
+    
+}

--- a/ij/plugin/Options.java
+++ b/ij/plugin/Options.java
@@ -6,6 +6,7 @@ import ij.io.*;
 import ij.plugin.filter.*;
 import ij.plugin.frame.LineWidthAdjuster;
 import java.awt.*;
+import java.awt.event.*;
 
 /** This plugin implements most of the commands
 	in the Edit/Options sub-menu. */
@@ -195,6 +196,27 @@ public class Options implements PlugIn {
 		Prefs.flipXZ = gd.getNextBoolean();
 	}
 	
+	class ButtonPanel extends Panel implements ActionListener{
+		/**
+		 * 
+		 */
+		private static final long serialVersionUID = 1L;
+
+		public ButtonPanel() {
+			super();
+			Button button = new Button("Set group names");
+			button.addActionListener(this);
+			this.add(button);			
+		}
+
+		@Override
+		public void actionPerformed(ActionEvent e) {
+			RoiGroupTable table = new RoiGroupTable();
+			table.showTable();
+		}
+		
+		
+	}
 	private void roiDefaults() {
 		Color color = Roi.getColor();
 		String cname = Colors.getColorName(color, "yellow");
@@ -202,7 +224,8 @@ public class Options implements PlugIn {
 		gd.addChoice("Color:", Colors.colors, cname);
 		gd.addNumericField("Stroke width:", Roi.getDefaultStrokeWidth(), 0);
 		gd.addNumericField("Group:", Roi.getDefaultGroup(), 0);
-		gd.addMessage("Color changes if group>0");		
+		gd.addMessage("Color changes if group>0");	
+		gd.addPanel(new ButtonPanel());
 		gd.showDialog();
 		if (gd.wasCanceled())
 			return;

--- a/ij/plugin/filter/Analyzer.java
+++ b/ij/plugin/filter/Analyzer.java
@@ -711,6 +711,7 @@ public class Analyzer implements PlugInFilter, Measurements {
 		int group = roi!=null?roi.getGroup():0;
 		if (group>0)
 			rt.addValue("Group", group);
+			rt.addValue("Group name", Roi.getNameOfGroup(group));
 	}
 	
 	private void clearSummary() {


### PR DESCRIPTION
This PR adds a new object in the ROI class: the `roiGroupNames` which corresponds to the mapping between the group numbers and associated user-defined group names.

__The group name is not an attribute of the ROI instances, only the group number.__  
This way we avoid issues like case-sensitivity or typos, and there is no problem if the users change group names during a session of annotations.

The group name mapping is rather stored as a variable in the ROI class, and as a preference in the ImageJ installation. (__store/retrieve in Prefs still to be done__).

Users can edit the group names via the Roi group table (screenshot below), accessible via the `Edit>Options>Roi defaults`
Group names can also be set/retrieved programatically.
If not defined `Roi.getNameOfGroup(x)` returns `groupx`

The group name is returned in the result table, next to the group number, if a ROI of group different than 0 is present.

In the future, importing/exporting the roi group table names should be implemented to allow sharing the group name mapping between users.

![image](https://user-images.githubusercontent.com/26764505/82035518-e68a2100-969f-11ea-8064-55da66332b40.png)
