### PR TITLE
Fix drawOval/fillOval for large images

### DIFF
--- a/ij/process/ImageProcessor.java
+++ b/ij/process/ImageProcessor.java
@@ -1240,14 +1240,14 @@ public abstract class ImageProcessor implements Cloneable {
 
 	/** Draws an elliptical shape. */
 	public void drawOval(int x, int y, int width, int height) {
-		if ((long)width*height>4*this.width*this.height) return;
+		if ((long)width*height>(long)4*this.width*this.height) return;
 		OvalRoi oval = new OvalRoi(x, y, width, height);
 		drawPolygon(oval.getPolygon());
 	}
 
 	/** Fills an elliptical shape. */
 	public void fillOval(int x, int y, int width, int height) {
-		if ((long)width*height>4*this.width*this.height) return;
+		if ((long)width*height>(long)4*this.width*this.height) return;
 		OvalRoi oval = new OvalRoi(x, y, width, height);
 		fillPolygon(oval.getPolygon());
 	}


### PR DESCRIPTION
drawOval/fillOval did not work for images larger than 2^29 pixels because the product `4*this.width*this.height` becomes larger than the maximum value for int.