### PR TITLE
Add support for scrollbars in TextAreas

### DIFF
--- a/ij/gui/GenericDialog.java
+++ b/ij/gui/GenericDialog.java
@@ -720,24 +720,32 @@ FocusListener, ItemListener, KeyListener, AdjustmentListener, WindowListener {
 		add(theLabel, c);
 		c.fill = GridBagConstraints.NONE;
     }
+    
+    /** Add one or two (side by side) text areas without scrollbars. 
+     * @see #addTextAreas(String, String, int, int, int)*/
+    public void addTextAreas(String text1, String text2, int rows, int columns) {
+    	// for backward compatibility
+    	addTextAreas(text1, text2, rows, columns, TextArea.SCROLLBARS_NONE);
+    }
 
 	/** Adds one or two (side by side) text areas.
 	* @param text1	initial contents of the first text area
 	* @param text2	initial contents of the second text area or null
 	* @param rows	the number of rows
 	* @param columns	the number of columns
+	* @param scrollbars one of java.awt.TextArea.SCROLLBARS constants to set if the text areas should have horizontal, vertical, both or no scrollbars
 	*/
-    public void addTextAreas(String text1, String text2, int rows, int columns) {
+    public void addTextAreas(String text1, String text2, int rows, int columns, int scrollbars) {
 		if (textArea1!=null) return;
 		Panel panel = new Panel();
 		Font font = new Font("SansSerif", Font.PLAIN, (int)(14*Prefs.getGuiScale()));
-		textArea1 = new TextArea(text1,rows,columns,TextArea.SCROLLBARS_NONE);
+		textArea1 = new TextArea(text1,rows,columns,scrollbars);
 		if (IJ.isLinux()) textArea1.setBackground(Color.white);
 		textArea1.setFont(font);
 		textArea1.addTextListener(this);
 		panel.add(textArea1);
 		if (text2!=null) {
-			textArea2 = new TextArea(text2,rows,columns,TextArea.SCROLLBARS_NONE);
+			textArea2 = new TextArea(text2,rows,columns,scrollbars);
 			if (IJ.isLinux()) textArea2.setBackground(Color.white);
 			textArea2.setFont(font);
 			panel.add(textArea2);


### PR DESCRIPTION
Add a new method signature `addTextAreas(String text1, String text2, int rows, int columns, int scrollbars)` to the GenericDialog class, which allows adding scrollbars to the TextAreas.

The former `addTextAreas(String text1, String text2, int rows, int columns)` will call the default NO_SCROLLBARS for backward compatibility.

I have some plugins with these kind of text area to paste a custom macro code, which can be a bit lengthy. 
Currently browsing the code is via the up/down arrows only, this would add support for scrolling with the mouse.

Example in jython
```python
from ij.gui import GenericDialog
from java.awt import TextArea

dialog = GenericDialog("Test") 
dialog.addTextAreas("Some input", "Test", 10, 20, TextArea.SCROLLBARS_VERTICAL_ONLY)
dialog.showDialog()
```
Huge image sorry..
![image](https://user-images.githubusercontent.com/26764505/112643628-db1d8f80-8e44-11eb-9ab1-2f492f349b56.png)
