### PR TITLE
ROI -AND- operation when holding down shift and alt

### DIFF
--- a/ij/gui/ImageCanvas.java
+++ b/ij/gui/ImageCanvas.java
@@ -1447,9 +1447,10 @@ public class ImageCanvas extends Canvas implements MouseListener, MouseMotionLis
 		int tool = Toolbar.getToolId();
 		if (tool>Toolbar.FREEROI && tool!=Toolbar.WAND && tool!=Toolbar.POINT)
 			{roi.modState = Roi.NO_MODS; return;}
-		if (e.isShiftDown())
+		if (e.isShiftDown()){
 			roi.modState = Roi.ADD_TO_ROI;
-		else if (e.isAltDown())
+			if (e.isAltDown()) roi.modState = Roi.KEEP_WITHIN_ROI;
+		}else if (e.isAltDown())
 			roi.modState = Roi.SUBTRACT_FROM_ROI;
 		else
 			roi.modState = Roi.NO_MODS;

--- a/ij/gui/Roi.java
+++ b/ij/gui/Roi.java
@@ -55,7 +55,7 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 	public static final int FERET_ARRAY_POINTOFFSET = 8; // Where point coordinates start in Feret array
 	private static final String NAMES_KEY = "group.names";
 
-	static final int NO_MODS=0, ADD_TO_ROI=1, SUBTRACT_FROM_ROI=2; // modification states
+	static final int NO_MODS=0, ADD_TO_ROI=1, SUBTRACT_FROM_ROI=2, KEEP_WITHIN_ROI=3; // modification states
 
 	int startX, startY, x, y, width, height;
 	double startXD, startYD;
@@ -1615,9 +1615,11 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 			s2 = (ShapeRoi)this;
 		else
 			s2 = new ShapeRoi(this);
-		if (previousRoi.modState==ADD_TO_ROI)
+		if (previousRoi.modState==ADD_TO_ROI) {
 			s1.or(s2);
-		else
+		}else if(previousRoi.modState==KEEP_WITHIN_ROI){
+			s1.and(s2);
+		}else
 			s1.not(s2);
 		previousRoi.modState = NO_MODS;
 		Roi roi2 = s1.trySimplify();
@@ -1656,8 +1658,10 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		makeOval(), makePolygon() and makeSelection() macro functions. */
 	public void update(boolean add, boolean subtract) {
 		if (previousRoi==null) return;
+		IJ.log("Update: "+add+" "+subtract);
 		if (add) {
 			previousRoi.modState = ADD_TO_ROI;
+			if(subtract) previousRoi.modState = KEEP_WITHIN_ROI;
 			modifyRoi();
 		} else if (subtract) {
 			previousRoi.modState = SUBTRACT_FROM_ROI;


### PR DESCRIPTION
When drawing ROIs, shift will perform an OR operation on previous ROIs, and alt (option) will perform a NOT operation.  Here, I have added an AND operation when the user holds shift and alt together. This will only keep the part of the previous ROI that is within the new ROI.

This has been useful to me, for example, when I have an accidentally large wand selection, and I only want to keep a small part of the selection.