### PR TITLE
IJ.open support opening local file from URL

### DIFF
--- a/ij/io/Opener.java
+++ b/ij/io/Opener.java
@@ -82,7 +82,7 @@ public class Opener {
 	 * @see ij.IJ#openImage(String)
 	*/
 	public void open(String path) {
-		boolean isURL = path.indexOf("://")>0;
+		boolean isURL = (path.contains("://") || path.contains("file:/"));
 		if (isURL && isText(path)) {
 			openTextURL(path);
 			return;
@@ -229,7 +229,7 @@ public class Opener {
 			path = getPath();
 		if (path==null) return null;
 		ImagePlus img = null;
-		if (path.indexOf("://")>0)
+		if (path.contains("://") || path.contains("file:/")) // path is a URL
 			img = openURL(path);
 		else
 			img = openImage(getDir(path), getName(path));


### PR DESCRIPTION
This small correction allows loading local files using their file URL (previously returned a file not found error).
This is useful for instance to load image or text/script files from the resource directory of compiled jars.
Example with a test jar (rename the extension to .jar, could not be uploaded as such) containing the blobs image (attached, to put in ImageJ.app/plugins) and a jython script loading the image from this jar.

[test-0.0.1-SNAPSHOT.zip](https://github.com/imagej/imagej1/files/7374840/test-0.0.1-SNAPSHOT.zip)
```python
from test import DummyClass
from ij import IJ

URL = DummyClass().getClass().getClassLoader().getResource("blobs.gif").toString() 
print URL
IJ.open(URL)
```
