### PR TITLE
Add DICOM metadata QA report

### DIFF
--- a/IJ_Props.txt
+++ b/IJ_Props.txt
@@ -416,6 +416,7 @@ utilities12="ImageJ Properties",ij.plugin.JavaProperties
 utilities13="Threads",ij.plugin.ThreadLister
 utilities14="Benchmark",ij.plugin.Benchmark
 utilities15="Reset...",ij.plugin.SimpleCommands("reset")
+utilities16="DICOM Metadata...",ij.plugin.DicomMetadata
 
 # Plugins installed in the Plugins/New submenu
 new_01="Macro",ij.plugin.NewPlugin("macro")
@@ -471,4 +472,3 @@ open27="T1 Head (16-bits)",ij.plugin.URLOpener("t1-head.zip")
 open28="T1 Head Renderings",ij.plugin.URLOpener("t1-rendering.zip")
 open29="TEM Filter",ij.plugin.URLOpener("TEM_filter_sample.jpg")
 open30="Tree Rings",ij.plugin.URLOpener("Tree_Rings.jpg")
-

--- a/ij/plugin/DicomMetadata.java
+++ b/ij/plugin/DicomMetadata.java
@@ -1,0 +1,23 @@
+package ij.plugin;
+import ij.*;
+import ij.text.TextWindow;
+import ij.util.DicomTools;
+
+/** Displays a compact DICOM acquisition, calibration and stack QA report. */
+public class DicomMetadata implements PlugIn {
+
+	public void run(String arg) {
+		ImagePlus imp = WindowManager.getCurrentImage();
+		if (imp==null) {
+			IJ.noImage();
+			return;
+		}
+		String summary = DicomTools.getMetadataSummary(imp);
+		if (summary.length()==0) {
+			IJ.error("DICOM Metadata", "The current image does not contain DICOM metadata.");
+			return;
+		}
+		new TextWindow("DICOM Metadata for "+imp.getTitle(), summary, 620, 520);
+	}
+
+}

--- a/ij/util/DicomTools.java
+++ b/ij/util/DicomTools.java
@@ -2,11 +2,36 @@ package ij.util;
 import ij.*;
 import ij.process.*;
 import ij.plugin.DICOM;
+import java.util.HashSet;
+import java.util.Locale;
 
 /** DICOM utilities */
 public class DicomTools {
 	private static final int MAX_DIGITS = 5;
+	private static final double SPACING_TOLERANCE = 1.0e-4;
 	private static String[] sliceLabels;
+
+	private static final String[][] SUMMARY_TAGS = {
+		{"Modality", "0008,0060"},
+		{"Manufacturer", "0008,0070"},
+		{"Model", "0008,1090"},
+		{"Protocol", "0018,1030"},
+		{"Series Description", "0008,103E"},
+		{"Body Part", "0018,0015"},
+		{"Scan Options", "0018,0022"},
+		{"Sequence Name", "0018,0024"},
+		{"Magnetic Field Strength", "0018,0087"},
+		{"Repetition Time", "0018,0080"},
+		{"Echo Time", "0018,0081"},
+		{"KVP", "0018,0060"},
+		{"Exposure Time", "0018,1150"},
+		{"X-Ray Tube Current", "0018,1151"},
+		{"Photometric Interpretation", "0028,0004"},
+		{"Transfer Syntax UID", "0002,0010"},
+		{"Rescale Slope", "0028,1053"},
+		{"Rescale Intercept", "0028,1052"},
+		{"Rescale Type", "0028,1054"}
+	};
 
 	/** Sorts a DICOM stack by image number. */
 	public static ImageStack sort(ImageStack stack) {
@@ -133,6 +158,42 @@ public class DicomTools {
 	public static String getTagName(String id) {
 		return DICOM.getTagName(id);
 	}
+
+	/** Returns the DICOM metadata string for the current image or stack slice. */
+	public static String getDicomMetadata(ImagePlus imp) {
+		if (imp==null)
+			return null;
+		String metadata = null;
+		if (imp.getStackSize()>1) {
+			ImageStack stack = imp.getStack();
+			String label = stack.getSliceLabel(imp.getCurrentSlice());
+			if (label!=null && label.indexOf('\n')>0)
+				metadata = label;
+		}
+		if (metadata==null)
+			metadata = (String)imp.getProperty("Info");
+		return isDicomMetadata(metadata)?metadata:null;
+	}
+
+	/** Returns a compact DICOM metadata and stack QA report that avoids direct patient ID tags. */
+	public static String getMetadataSummary(ImagePlus imp) {
+		String metadata = getDicomMetadata(imp);
+		if (metadata==null)
+			return "";
+		StringBuffer sb = new StringBuffer(2048);
+		sb.append("DICOM Metadata Summary\n");
+		sb.append("Image: ").append(imp.getTitle()).append("\n");
+		sb.append("Dimensions: ").append(imp.getWidth()).append(" x ").append(imp.getHeight());
+		if (imp.getStackSize()>1)
+			sb.append(" x ").append(imp.getStackSize());
+		sb.append("\n");
+		sb.append("Bit depth: ").append(imp.getBitDepth()).append("-bit\n");
+		appendSummaryTags(sb, metadata);
+		appendCalibrationSummary(sb, imp, metadata);
+		if (imp.getStackSize()>1)
+			appendStackSummary(sb, imp.getStack());
+		return sb.toString();
+	}
 		
 	private static double getSeriesNumber(String tags) {
 		double series = getNumericTag(tags, "0020,0011");
@@ -149,12 +210,15 @@ public class DicomTools {
 		return Tools.parseDouble(value);
 	}
 
-	private static String getTag(String hdr, String tag) {
+	/** Returns the value of a DICOM tag in an ImageJ DICOM metadata string. */
+	public static String getTag(String hdr, String tag) {
 		if (hdr==null) return null;
+		tag = normalizeTag(tag);
+		if (tag==null) return null;
 		int index1 = hdr.indexOf(tag);
 		if (index1==-1) return null;
 		//IJ.log(hdr.charAt(index1+11)+"   "+hdr.substring(index1,index1+20));
-		if (hdr.charAt(index1+11)=='>') {
+		if (index1+11<hdr.length() && hdr.charAt(index1+11)=='>') {
 			// ignore tags in sequences
 			index1 = hdr.indexOf(tag, index1+10);
 			if (index1==-1) return null;
@@ -162,8 +226,245 @@ public class DicomTools {
 		index1 = hdr.indexOf(":", index1);
 		if (index1==-1) return null;
 		int index2 = hdr.indexOf("\n", index1);
+		if (index2==-1) index2 = hdr.length();
 		String value = hdr.substring(index1+1, index2);
 		return value;
+	}
+
+	private static void appendSummaryTags(StringBuffer sb, String metadata) {
+		sb.append("\nAcquisition\n");
+		for (int i=0; i<SUMMARY_TAGS.length; i++)
+			appendTag(sb, metadata, SUMMARY_TAGS[i][0], SUMMARY_TAGS[i][1]);
+	}
+
+	private static void appendCalibrationSummary(StringBuffer sb, ImagePlus imp, String metadata) {
+		ij.measure.Calibration cal = imp.getCalibration();
+		String spacing = cleanTag(metadata, "0028,0030");
+		String imagerSpacing = cleanTag(metadata, "0018,1164");
+		String sliceThickness = cleanTag(metadata, "0018,0050");
+		String spacingBetweenSlices = cleanTag(metadata, "0018,0088");
+		sb.append("\nGeometry and Calibration QA\n");
+		if (spacing!=null)
+			sb.append("DICOM Pixel Spacing: ").append(formatPixelSpacing(spacing)).append("\n");
+		else if (imagerSpacing!=null)
+			sb.append("DICOM Imager Pixel Spacing: ").append(formatPixelSpacing(imagerSpacing)).append("\n");
+		else
+			sb.append("DICOM Pixel Spacing: missing\n");
+		appendTag(sb, metadata, "Slice Thickness", "0018,0050");
+		appendTag(sb, metadata, "Spacing Between Slices", "0018,0088");
+		appendTag(sb, metadata, "Image Orientation", "0020,0037");
+		appendTag(sb, metadata, "Image Position", "0020,0032");
+		sb.append("ImageJ Calibration: ").append(formatNumber(cal.pixelWidth)).append(" x ")
+			.append(formatNumber(cal.pixelHeight)).append(" x ")
+			.append(formatNumber(cal.pixelDepth)).append(" ")
+			.append(cal.getUnit()).append("\n");
+		appendCalibrationComparison(sb, cal, spacing, imagerSpacing, sliceThickness, spacingBetweenSlices);
+	}
+
+	private static void appendCalibrationComparison(StringBuffer sb, ij.measure.Calibration cal, String spacing, String imagerSpacing, String sliceThickness, String spacingBetweenSlices) {
+		String pixelSpacing = spacing!=null?spacing:imagerSpacing;
+		double[] xy = parseDoubles(pixelSpacing);
+		if (xy!=null && xy.length>=2 && isMillimeterUnit(cal.getXUnit()) && isMillimeterUnit(cal.getYUnit())) {
+			double dicomY = xy[0];
+			double dicomX = xy[1];
+			if (!nearlyEqual(cal.pixelWidth, dicomX) || !nearlyEqual(cal.pixelHeight, dicomY))
+				sb.append("Warning: ImageJ XY calibration differs from DICOM pixel spacing.\n");
+		}
+		double z = getFirstNumber(spacingBetweenSlices);
+		if (Double.isNaN(z))
+			z = getFirstNumber(sliceThickness);
+		if (!Double.isNaN(z) && isMillimeterUnit(cal.getZUnit()) && !nearlyEqual(cal.pixelDepth, z))
+			sb.append("Warning: ImageJ Z calibration differs from DICOM slice spacing/thickness.\n");
+	}
+
+	private static void appendStackSummary(StringBuffer sb, ImageStack stack) {
+		sb.append("\nStack QA\n");
+		sb.append("Slices assessed: ").append(stack.size()).append("\n");
+		appendConsistencyCheck(sb, stack, "Series Instance UID", "0020,000E");
+		appendConsistencyCheck(sb, stack, "Frame of Reference UID", "0020,0052");
+		appendConsistencyCheck(sb, stack, "Rows", "0028,0010");
+		appendConsistencyCheck(sb, stack, "Columns", "0028,0011");
+		appendConsistencyCheck(sb, stack, "Pixel Spacing", "0028,0030");
+		appendConsistencyCheck(sb, stack, "Image Orientation", "0020,0037");
+		appendConsistencyCheck(sb, stack, "Rescale Slope", "0028,1053");
+		appendConsistencyCheck(sb, stack, "Rescale Intercept", "0028,1052");
+		appendPositionSpacingCheck(sb, stack);
+	}
+
+	private static void appendConsistencyCheck(StringBuffer sb, ImageStack stack, String label, String tag) {
+		HashSet values = new HashSet();
+		int missing = 0;
+		for (int i=1; i<=stack.size(); i++) {
+			String value = cleanTag(getSliceLabel(stack, i), tag);
+			if (value==null)
+				missing++;
+			else
+				values.add(value);
+		}
+		sb.append(label).append(": ");
+		if (missing==stack.size())
+			sb.append("missing");
+		else if (values.size()==1 && missing==0)
+			sb.append("consistent");
+		else {
+			sb.append("varies");
+			if (values.size()>0)
+				sb.append(" (").append(values.size()).append(" values");
+			if (missing>0)
+				sb.append(values.size()>0?", ":" (").append(missing).append(" missing");
+			sb.append(")");
+		}
+		sb.append("\n");
+	}
+
+	private static void appendPositionSpacingCheck(StringBuffer sb, ImageStack stack) {
+		double[] previous = null;
+		int previousSlice = 0;
+		int missing = 0;
+		int intervals = 0;
+		double min = Double.MAX_VALUE;
+		double max = -Double.MAX_VALUE;
+		double sum = 0.0;
+		for (int i=1; i<=stack.size(); i++) {
+			double[] position = parseTriplet(cleanTag(getSliceLabel(stack, i), "0020,0032"));
+			if (position==null) {
+				missing++;
+				continue;
+			}
+			if (previous!=null && i==previousSlice+1) {
+				double distance = distance(previous, position);
+				if (distance<min) min = distance;
+				if (distance>max) max = distance;
+				sum += distance;
+				intervals++;
+			}
+			previous = position;
+			previousSlice = i;
+		}
+		sb.append("Image Position spacing: ");
+		if (intervals==0)
+			sb.append("not available");
+		else {
+			double mean = sum/intervals;
+			sb.append(formatNumber(mean)).append(" mm mean");
+			if (!nearlyEqual(min, max))
+				sb.append(" (range ").append(formatNumber(min)).append("-").append(formatNumber(max)).append(")");
+			if (spacingVariationIsHigh(min, max, mean))
+				sb.append(" - warning: non-uniform");
+		}
+		if (missing>0)
+			sb.append(" (").append(missing).append(" missing positions)");
+		sb.append("\n");
+	}
+
+	private static void appendTag(StringBuffer sb, String metadata, String label, String tag) {
+		String value = cleanTag(metadata, tag);
+		if (value!=null)
+			sb.append(label).append(": ").append(value).append("\n");
+	}
+
+	private static String cleanTag(String metadata, String tag) {
+		return cleanValue(getTag(metadata, tag));
+	}
+
+	private static String cleanValue(String value) {
+		if (value==null)
+			return null;
+		value = value.trim();
+		return value.length()>0?value:null;
+	}
+
+	private static String formatPixelSpacing(String spacing) {
+		double[] xy = parseDoubles(spacing);
+		if (xy!=null && xy.length>=2)
+			return formatNumber(xy[1])+" x "+formatNumber(xy[0])+" mm (x by y)";
+		return spacing;
+	}
+
+	private static String formatNumber(double value) {
+		String s = IJ.d2s(value, 6, 9);
+		int exponent = s.indexOf('E');
+		String suffix = "";
+		if (exponent>=0) {
+			suffix = s.substring(exponent);
+			s = s.substring(0, exponent);
+		}
+		if (s.indexOf('.')>=0) {
+			while (s.endsWith("0"))
+				s = s.substring(0, s.length()-1);
+			if (s.endsWith("."))
+				s = s.substring(0, s.length()-1);
+		}
+		return s + suffix;
+	}
+
+	private static double[] parseTriplet(String value) {
+		double[] values = parseDoubles(value);
+		if (values==null || values.length<3)
+			return null;
+		return values;
+	}
+
+	private static double[] parseDoubles(String value) {
+		if (value==null)
+			return null;
+		String[] parts = value.split("\\\\");
+		double[] values = new double[parts.length];
+		for (int i=0; i<parts.length; i++) {
+			values[i] = Tools.parseDouble(parts[i].trim());
+			if (Double.isNaN(values[i]))
+				return null;
+		}
+		return values;
+	}
+
+	private static double getFirstNumber(String value) {
+		double[] values = parseDoubles(value);
+		return values!=null && values.length>0?values[0]:Double.NaN;
+	}
+
+	private static double distance(double[] p1, double[] p2) {
+		double dx = p2[0] - p1[0];
+		double dy = p2[1] - p1[1];
+		double dz = p2[2] - p1[2];
+		return Math.sqrt(dx*dx + dy*dy + dz*dz);
+	}
+
+	private static boolean nearlyEqual(double a, double b) {
+		double tolerance = Math.max(Math.abs(a), Math.abs(b))*SPACING_TOLERANCE;
+		if (tolerance<1.0e-6)
+			tolerance = 1.0e-6;
+		return Math.abs(a-b)<=tolerance;
+	}
+
+	private static boolean spacingVariationIsHigh(double min, double max, double mean) {
+		if (mean==0.0)
+			return false;
+		return Math.abs(max-min)/Math.abs(mean)>SPACING_TOLERANCE;
+	}
+
+	private static boolean isMillimeterUnit(String unit) {
+		if (unit==null)
+			return false;
+		unit = unit.toLowerCase(Locale.US);
+		return unit.equals("mm") || unit.equals("millimeter") || unit.equals("millimeters");
+	}
+
+	private static boolean isDicomMetadata(String metadata) {
+		if (metadata==null)
+			return false;
+		return metadata.indexOf("7FE0,0010")>=0 ||
+			(metadata.indexOf("0028,0010")>=0 && metadata.indexOf("0028,0011")>=0) ||
+			metadata.indexOf("0008,0060")>=0;
+	}
+
+	private static String normalizeTag(String tag) {
+		if (tag==null)
+			return null;
+		tag = tag.trim().toUpperCase(Locale.US);
+		if (tag.length()==8 && tag.indexOf(',')==-1)
+			tag = tag.substring(0,4) + "," + tag.substring(4);
+		return tag;
 	}
 
 }

--- a/tests/ij/util/DicomToolsTest.java
+++ b/tests/ij/util/DicomToolsTest.java
@@ -1,0 +1,91 @@
+package ij.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.measure.Calibration;
+import ij.process.ShortProcessor;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DicomTools}.
+ */
+public class DicomToolsTest {
+
+	@Test
+	public void testGetTagFromMetadata() {
+		String metadata = line("0008,0060", "Modality", "CT") +
+			line("0028,0030", "Pixel Spacing", "0.5\\0.5");
+		assertEquals(" CT", DicomTools.getTag(metadata, "0008,0060"));
+		assertEquals(" CT", DicomTools.getTag(metadata, "00080060"));
+		assertEquals(" 0.5\\0.5", DicomTools.getTag(metadata, "0028,0030"));
+		assertNull(DicomTools.getTag(metadata, "0018,0050"));
+	}
+
+	@Test
+	public void testGetTagSkipsSequenceValues() {
+		String metadata = "0010,0010  >Patient's Name: Hidden\n" +
+			line("0010,0010", "Patient's Name", "Visible");
+		assertEquals(" Visible", DicomTools.getTag(metadata, "0010,0010"));
+	}
+
+	@Test
+	public void testMetadataSummaryReportsCalibrationAndStackQA() {
+		ImageStack stack = new ImageStack(2, 2);
+		stack.addSlice("slice 1\n" + metadata("0"), new short[4]);
+		stack.addSlice("slice 2\n" + metadata("1.25"), new short[4]);
+		ImagePlus imp = new ImagePlus("QA Stack", stack);
+		Calibration cal = imp.getCalibration();
+		cal.pixelWidth = 0.5;
+		cal.pixelHeight = 0.5;
+		cal.pixelDepth = 1.25;
+		cal.setUnit("mm");
+		String summary = DicomTools.getMetadataSummary(imp);
+		assertTrue(summary.indexOf("DICOM Metadata Summary")>=0);
+		assertTrue(summary.indexOf("Modality: CT")>=0);
+		assertTrue(summary.indexOf("DICOM Pixel Spacing: 0.5 x 0.5 mm (x by y)")>=0);
+		assertTrue(summary.indexOf("ImageJ Calibration: 0.5 x 0.5 x 1.25 mm")>=0);
+		assertTrue(summary.indexOf("Pixel Spacing: consistent")>=0);
+		assertTrue(summary.indexOf("Image Position spacing: 1.25 mm mean")>=0);
+		assertFalse(summary.indexOf("Warning:")>=0);
+	}
+
+	@Test
+	public void testMetadataSummaryWarnsForCalibrationMismatch() {
+		ImagePlus imp = new ImagePlus("Mismatch", new ShortProcessor(2, 2));
+		imp.setProperty("Info", metadata("0"));
+		Calibration cal = imp.getCalibration();
+		cal.pixelWidth = 1.0;
+		cal.pixelHeight = 1.0;
+		cal.pixelDepth = 2.0;
+		cal.setUnit("mm");
+		String summary = DicomTools.getMetadataSummary(imp);
+		assertTrue(summary.indexOf("Warning: ImageJ XY calibration differs from DICOM pixel spacing.")>=0);
+		assertTrue(summary.indexOf("Warning: ImageJ Z calibration differs from DICOM slice spacing/thickness.")>=0);
+	}
+
+	private static String metadata(String z) {
+		return line("0008,0060", "Modality", "CT") +
+			line("0020,000E", "Series Instance UID", "1.2.3") +
+			line("0020,0052", "Frame of Reference UID", "1.2.3.4") +
+			line("0028,0010", "Rows", "2") +
+			line("0028,0011", "Columns", "2") +
+			line("0028,0030", "Pixel Spacing", "0.5\\0.5") +
+			line("0018,0050", "Slice Thickness", "1.25") +
+			line("0018,0088", "Spacing Between Slices", "1.25") +
+			line("0020,0032", "Image Position (Patient)", "0\\0\\" + z) +
+			line("0020,0037", "Image Orientation (Patient)", "1\\0\\0\\0\\1\\0") +
+			line("0028,1053", "Rescale Slope", "1") +
+			line("0028,1052", "Rescale Intercept", "-1024") +
+			line("7FE0,0010", "Pixel Data", "0");
+	}
+
+	private static String line(String tag, String name, String value) {
+		return tag + "  " + name + ": " + value + "\n";
+	}
+
+}


### PR DESCRIPTION
Adds an optional DICOM metadata summary command with acquisition,
calibration, and stack consistency checks, plus focused tests for the
metadata parsing/reporting utilities.